### PR TITLE
Rename dependent composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "paragonie/random_compat": "^1.0",
-        "ircmaxell/password_compat": "^1.0"
+        "ircmaxell/password-compat": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*"


### PR DESCRIPTION
Package name for [Password Compat](https://packagist.org/packages/ircmaxell/password-compat) has an underscore instead of a hyphen

